### PR TITLE
Added preamble option

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (file, o) {
     },
     function () { // end
       try {
-        this.queue(preamble + 'module.exports = ' + riot.compile(content, opts, file));
+        this.queue((opts.preamble || preamble) + 'module.exports = ' + riot.compile(content, opts, file));
         this.emit('end');
       } catch (e) {
         this.emit('error', e);

--- a/test/compile.js
+++ b/test/compile.js
@@ -87,3 +87,18 @@ test('module exports riot tag', function (t) {
     t.ok(out[1].source.match(/module.exports = riot.tag2/), 'riot tag');
   }));
 });
+
+test('custom preamble', function (t) {
+  var file = path.join(__dirname, 'todo.tag');
+  var p = moduleDeps();
+
+  p.write({ transform: riotify, options: {preamble: 'custom-preamble;'} });
+  p.write({ file: file, id: file, entry: true });
+  p.end();
+
+  t.plan(1);
+  p.pipe(concat(function (out) {
+    t.ok(out[0].source.match(/^custom-preamble;/), 'custom preamble');
+  }));
+});
+


### PR DESCRIPTION
`preamble` references to riot. but since all the tags are compiled it is sometimes okay to use `riot/riot.min` which reduces eventual builds. This PR allows optionally to override the preamble for just that purpose.
