### PR TITLE
v2

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "mocha": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "eqeqeq": ["error", "smart"],
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "no-cond-assign": "off",
+    "no-console": "off",
+    "no-unexpected-multiline": "error",
+    "quotes": ["error", "single", "avoid-escape"],
+    "semi": ["error", "never"]
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
----
 language: node_js
 node_js:
-- '0.10'
-script:
-  - npm install
-  - npm test
+  - '4.*'
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2.0.0
+
+  * Compatible with Riot 3.0.0
+  * Moved to Riot organization
+  * Make riot-compiler a peerDependency
+  * Add eslint
+
 ## 1.0.1
 
   * Passing the file name to the riot compiler #30

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build
-Status](https://travis-ci.org/jhthorsen/riotify.svg)](https://travis-ci.org/jhthorsen/riotify)
+Status](https://travis-ci.org/riot/riotify.svg)](https://travis-ci.org/riot/riotify)
 
 # riotify
 
@@ -7,7 +7,9 @@ Status](https://travis-ci.org/jhthorsen/riotify.svg)](https://travis-ci.org/jhth
 
 ## Installation
 
-    npm install riotify
+```bash
+$ npm install riotify
+```
 
 ## Usage
 
@@ -17,26 +19,32 @@ This module is meant to be used together with
 
 Either of the two commands below result creates the same result:
 
-    browserify -t riotify app.js
-    module-deps -t riotify app.js | browser-pack
+```bash
+$ browserify -t riotify app.js
+$ module-deps -t riotify app.js | browser-pack
+```
 
 Example `app.js`:
 
-    var riot = require('riot')
-    var todo = require('./todo.tag')
-    riot.mount(todo)
+```javascript
+var riot = require('riot')
+var todo = require('./todo.tag')
+riot.mount(todo)
+```
 
 Example `todo.tag`:
 
-    <todo>
-      <div each={ items }>
-        <h3>{ title }</h3>
-      </div>
-      
-      // a tag file can contain any JavaScript, even require()
-      var resources = require('../resources.json')    
-      this.items = [ { title: resources.en.first }, { title: resources.en.second } ]
-    </todo>
+```html
+<todo>
+  <div each={ items }>
+    <h3>{ title }</h3>
+  </div>
+
+  // a tag file can contain any JavaScript, even require()
+  var resources = require('../resources.json')    
+  this.items = [ { title: resources.en.first }, { title: resources.en.second } ]
+</todo>
+```
 
 Note that your tag files actually need to have the extension ".tag".
 
@@ -44,7 +52,9 @@ Note that your tag files actually need to have the extension ".tag".
 
 This plugin can give riot's compile options.
 
-    % browserify -t [ riotify --type coffeescript --template jade ] app.js
+```bash
+$ browserify -t [ riotify --type coffeescript --template jade ] app.js
+```
 
 You can also configure it in package.json
 
@@ -61,16 +71,16 @@ You can also configure it in package.json
 
 #### Available option
 
-* compact: `Boolean`
-  * Minify `</p> <p>` to `</p><p>`
-* expr: `Boolean`
-  * Run expressions trough parser defined with `--type`
-* type: `String, coffeescript | cs | es6 | none`
-  * JavaScript pre-processor
-* template: `String, jade`
-  * HTML pre-processor
-* ext: `String`
-  * custom extension, you’re free to use any file extension for your tags (instead of default .tag):
+- compact: `Boolean`
+  - Minify `</p> <p>` to `</p><p>`
+- expr: `Boolean`
+  - Run expressions trough parser defined with `--type`
+- type: `String, coffeescript | cs | es6 | none`
+  - JavaScript pre-processor
+- template: `String, jade`
+  - HTML pre-processor
+- ext: `String`
+  - custom extension, you’re free to use any file extension for your tags (instead of default .tag):
 
 See more: https://muut.com/riotjs/compiler.html
 
@@ -95,7 +105,9 @@ These are the simplest cases. `uglify` and `sourcemaps` would be needed.
 
 ## Tests
 
-    npm test
+```bash
+$ npm test
+```
 
 ## Author
 

--- a/index.js
+++ b/index.js
@@ -1,23 +1,26 @@
-var through = require('through');
-var riot = require('riot');
-var preamble = "var riot = require('riot');\n";
+'use strict'
+
+const through = require('through')
+const compiler = require('riot-compiler')
+const preamble = "var riot = require('riot');\n"
 
 module.exports = function (file, o) {
-  var opts = o || {};
-  var ext = opts.ext || 'tag';
-  var content = '';
+  const opts = o || {}
+  const ext = opts.ext || 'tag'
+  let content = ''
 
-  return !file.match('\.' + ext + '$') ? through() : through(
+  return !file.match(`\.${ ext }$`) ? through() : through(
     function (chunk) { // write
-      content += chunk.toString();
+      content += chunk.toString()
     },
     function () { // end
       try {
-        this.queue(preamble + 'module.exports = ' + riot.compile(content, opts, file));
-        this.emit('end');
+        const compiled = compiler.compile(content, opts, file)
+        this.queue(`${ preamble }module.exports = ${ compiled }`)
+        this.emit('end')
       } catch (e) {
-        this.emit('error', e);
+        this.emit('error', e)
       }
     }
-  );
-};
+  )
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.1",
   "description": "browserify plugin for riot tag files",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
     "through": "^2.3.8"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eslint": "^3.10.2",
     "module-deps": "^4.0.8",
     "tape": "^4.6.3",
+    "riot": "^3.0.0",
     "riot-compiler": "^3.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
   },
   "devDependencies": {
     "concat-stream": "^1.4.0",
+    "eslint": "^3.10.2",
     "module-deps": "^3.6.0",
     "tape": "^2.12.1"
   },
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "npm run eslint && npm run tape",
+    "tape": "tape test/*.js",
+    "eslint": "eslint index.js test/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "description": "browserify plugin for riot tag files",
   "main": "index.js",
   "dependencies": {
-    "riot": "^2.3.0",
-    "through": "^2.3.0"
+    "through": "^2.3.8"
   },
   "devDependencies": {
-    "concat-stream": "^1.4.0",
+    "concat-stream": "^1.5.2",
     "eslint": "^3.10.2",
-    "module-deps": "^3.6.0",
-    "tape": "^2.12.1"
+    "module-deps": "^4.0.8",
+    "tape": "^4.6.3"
   },
   "scripts": {
     "test": "npm run eslint && npm run tape",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "concat-stream": "^1.5.2",
     "eslint": "^3.10.2",
     "module-deps": "^4.0.8",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "riot-compiler": "^3.0.0"
+  },
+  "peerDependencies": {
+    "riot-compiler": "^3.0.0"
   },
   "scripts": {
     "test": "npm run eslint && npm run tape",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jhthorsen/riotify.git"
+    "url": "https://github.com/riot/riotify.git"
   },
   "keywords": [
     "browserify",
@@ -30,6 +30,6 @@
   "author": "Jan Henning Thorsen",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jhthorsen/riotify/issues"
+    "url": "https://github.com/riot/riotify/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riotify",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "browserify plugin for riot tag files",
   "main": "index.js",
   "files": [

--- a/test/compile.js
+++ b/test/compile.js
@@ -1,89 +1,89 @@
-var test = require('tape');
-var concat = require('concat-stream');
-var moduleDeps = require('module-deps');
-var path = require('path');
-var riotify = require('../');
+const test = require('tape')
+const concat = require('concat-stream')
+const moduleDeps = require('module-deps')
+const path = require('path')
+const riotify = require('../')
 
-test('ignore', function (t) {
-  var file = path.join(__dirname, 'ignore.ext');
-  var p = moduleDeps();
+test('ignore', t => {
+  const file = path.join(__dirname, 'ignore.ext')
+  const p = moduleDeps()
 
-  p.write({ transform: riotify, options: {} });
-  p.write({ file: file, id: file, entry: true });
-  p.end();
+  p.write({ transform: riotify, options: {} })
+  p.write({ file, id: file, entry: true })
+  p.end()
 
-  t.plan(3);
-  p.pipe(concat(function (out) {
-    t.ok(out[0], 'got output element');
-    t.ok(out[0].source.length, 'got output element with source');
-    t.ok(out[0].source.match(/^<todo>/), 'skipped ignore.ext');
-  }));
-});
+  t.plan(3)
+  p.pipe(concat(out => {
+    t.ok(out[0], 'got output element')
+    t.ok(out[0].source.length, 'got output element with source')
+    t.ok(out[0].source.match(/^<todo>/), 'skipped ignore.ext')
+  }))
+})
 
-test('compile', function (t) {
-  var file = path.join(__dirname, 'todo.tag');
-  var p = moduleDeps();
+test('compile', t => {
+  const file = path.join(__dirname, 'todo.tag')
+  const p = moduleDeps()
 
-  p.write({ transform: riotify, options: {} });
-  p.write({ file: file, id: file, entry: true });
-  p.end();
+  p.write({ transform: riotify, options: {} })
+  p.write({ file, id: file, entry: true })
+  p.end()
 
-  t.plan(6);
-  p.pipe(concat(function (out) {
-    t.is(out.length, 2, 'got two files as output');
-    t.ok(out[0].id.match(/riot\.js$/), 'out.0 is riot.js');
-    t.ok(out[0].source.match(/module.exports/), 'riot.js');
-    t.ok(out[1].id.match(/todo\.tag$/), 'out.1 is todo.tag');
-    t.ok(out[1].source.match(/var riot = require\('riot'\);/), 'require riot');
-    t.ok(out[1].source.match(/riot.tag2\(.*todo/), 'compiled compile.tag');
-  }));
-});
+  t.plan(6)
+  p.pipe(concat(out => {
+    t.is(out.length, 2, 'got two files as output')
+    t.ok(out[0].id.match(/riot\.js$/), 'out.0 is riot.js')
+    t.ok(out[0].source.match(/module.exports/), 'riot.js')
+    t.ok(out[1].id.match(/todo\.tag$/), 'out.1 is todo.tag')
+    t.ok(out[1].source.match(/var riot = require\('riot'\);/), 'require riot')
+    t.ok(out[1].source.match(/riot.tag2\(.*todo/), 'compiled compile.tag')
+  }))
+})
 
-test('compile-custom-ext', function (t) {
-  var file = path.join(__dirname, 'customext.html');
-  var p = moduleDeps();
+test('compile-custom-ext', t => {
+  const file = path.join(__dirname, 'customext.html')
+  const p = moduleDeps()
 
-  p.write({ transform: riotify, options: {ext: "html"} });
-  p.write({ file: file, id: file, entry: true });
-  p.end();
+  p.write({ transform: riotify, options: {ext: 'html'} })
+  p.write({ file, id: file, entry: true })
+  p.end()
 
-  t.plan(6);
-  p.pipe(concat(function (out) {
-    t.is(out.length, 2, 'got two files as output');
-    t.ok(out[0].id.match(/riot\.js$/), 'out.0 is riot.js');
-    t.ok(out[0].source.match(/module.exports/), 'riot.js');
-    t.ok(out[1].id.match(/customext\.html$/), 'out.1 is customext.html');
-    t.ok(out[1].source.match(/var riot = require\('riot'\);/), 'require riot');
-    t.ok(out[1].source.match(/riot.tag2\(.*customext/), 'compiled compile.tag');
-  }));
-});
+  t.plan(6)
+  p.pipe(concat(out => {
+    t.is(out.length, 2, 'got two files as output')
+    t.ok(out[0].id.match(/riot\.js$/), 'out.0 is riot.js')
+    t.ok(out[0].source.match(/module.exports/), 'riot.js')
+    t.ok(out[1].id.match(/customext\.html$/), 'out.1 is customext.html')
+    t.ok(out[1].source.match(/var riot = require\('riot'\);/), 'require riot')
+    t.ok(out[1].source.match(/riot.tag2\(.*customext/), 'compiled compile.tag')
+  }))
+})
 
-test('compile-custom-ext-ignore', function (t) {
-  var file = path.join(__dirname, 'todo.tag');
-  var p = moduleDeps();
+test('compile-custom-ext-ignore', t => {
+  const file = path.join(__dirname, 'todo.tag')
+  const p = moduleDeps()
 
-  p.write({ transform: riotify, options: {ext: "html"} });
-  p.write({ file: file, id: file, entry: true });
-  p.end();
+  p.write({ transform: riotify, options: {ext: 'html'} })
+  p.write({ file, id: file, entry: true })
+  p.end()
 
-  t.plan(3);
-  p.pipe(concat(function (out) {
-    t.ok(out[0], 'got output element');
-    t.ok(out[0].source.length, 'got output element with source');
-    t.ok(out[0].source.match(/^<todo>/), 'skipped todo.tag');
-  }));
-});
+  t.plan(3)
+  p.pipe(concat(out => {
+    t.ok(out[0], 'got output element')
+    t.ok(out[0].source.length, 'got output element with source')
+    t.ok(out[0].source.match(/^<todo>/), 'skipped todo.tag')
+  }))
+})
 
-test('module exports riot tag', function (t) {
-  var file = path.join(__dirname, 'todo.tag');
-  var p = moduleDeps();
+test('module exports riot tag', t => {
+  const file = path.join(__dirname, 'todo.tag')
+  const p = moduleDeps()
 
-  p.write({ transform: riotify });
-  p.write({ file: file, id: file, entry: true });
-  p.end();
+  p.write({ transform: riotify })
+  p.write({ file, id: file, entry: true })
+  p.end()
 
-  t.plan(1);
-  p.pipe(concat(function (out) {
-    t.ok(out[1].source.match(/module.exports = riot.tag2/), 'riot tag');
-  }));
-});
+  t.plan(1)
+  p.pipe(concat(out => {
+    t.ok(out[1].source.match(/module.exports = riot.tag2/), 'riot tag')
+  }))
+})

--- a/test/compile.js
+++ b/test/compile.js
@@ -16,7 +16,7 @@ test('ignore', t => {
   p.pipe(concat(out => {
     t.ok(out[0], 'got output element')
     t.ok(out[0].source.length, 'got output element with source')
-    t.ok(out[0].source.match(/^<todo>/), 'skipped ignore.ext')
+    t.ok(/^<todo>/.test(out[0].source), 'skipped ignore.ext')
   }))
 })
 
@@ -31,11 +31,11 @@ test('compile', t => {
   t.plan(6)
   p.pipe(concat(out => {
     t.is(out.length, 2, 'got two files as output')
-    t.ok(out[0].id.match(/riot\.js$/), 'out.0 is riot.js')
-    t.ok(out[0].source.match(/module.exports/), 'riot.js')
-    t.ok(out[1].id.match(/todo\.tag$/), 'out.1 is todo.tag')
-    t.ok(out[1].source.match(/var riot = require\('riot'\);/), 'require riot')
-    t.ok(out[1].source.match(/riot.tag2\(.*todo/), 'compiled compile.tag')
+    t.ok(/riot\.js$/.test(out[0].id), 'out.0 is riot.js')
+    t.ok(/RIOT_TAG_IS/.test(out[0].source), 'riot.js')
+    t.ok(/todo\.tag$/.test(out[1].id), 'out.1 is todo.tag')
+    t.ok(/var riot = require\('riot'\);/.test(out[1].source), 'require riot')
+    t.ok(/riot\.tag2\(.*todo/.test(out[1].source), 'compiled compile.tag')
   }))
 })
 
@@ -50,11 +50,11 @@ test('compile-custom-ext', t => {
   t.plan(6)
   p.pipe(concat(out => {
     t.is(out.length, 2, 'got two files as output')
-    t.ok(out[0].id.match(/riot\.js$/), 'out.0 is riot.js')
-    t.ok(out[0].source.match(/module.exports/), 'riot.js')
-    t.ok(out[1].id.match(/customext\.html$/), 'out.1 is customext.html')
-    t.ok(out[1].source.match(/var riot = require\('riot'\);/), 'require riot')
-    t.ok(out[1].source.match(/riot.tag2\(.*customext/), 'compiled compile.tag')
+    t.ok(/riot\.js$/.test(out[0].id), 'out.0 is riot.js')
+    t.ok(/RIOT_TAG_IS/.test(out[0].source), 'riot.js')
+    t.ok(/customext\.html$/.test(out[1].id), 'out.1 is customext.html')
+    t.ok(/var riot = require\('riot'\);/.test(out[1].source), 'require riot')
+    t.ok(/riot.tag2\(.*customext/.test(out[1].source), 'compiled compile.tag')
   }))
 })
 
@@ -70,7 +70,7 @@ test('compile-custom-ext-ignore', t => {
   p.pipe(concat(out => {
     t.ok(out[0], 'got output element')
     t.ok(out[0].source.length, 'got output element with source')
-    t.ok(out[0].source.match(/^<todo>/), 'skipped todo.tag')
+    t.ok(/^<todo>/.test(out[0].source), 'skipped todo.tag')
   }))
 })
 
@@ -84,6 +84,6 @@ test('module exports riot tag', t => {
 
   t.plan(1)
   p.pipe(concat(out => {
-    t.ok(out[1].source.match(/module.exports = riot.tag2/), 'riot tag')
+    t.ok(/module.exports = riot.tag2/.test(out[1].source), 'riot tag')
   }))
 })


### PR DESCRIPTION
- support RIot 3
- ES6ify
- drop the support for Node 0.x: `0.12` --> `4.*` in `.travis.yml`
- follow the coding style of Riot
- eslint